### PR TITLE
Bypass a bug of podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Be sure to view the following repositories to understand all the customizable op
 | `MACRO_SECURITY_LEVEL`           | Macro Security Level `1` Medium `0` Low                                                                            | `1`           |
 | `ENABLE_METRICS_UNAUTHENTICATED` | Enable Unauthenticated Metrics                                                                                     | `FALSE`       |
 | `ENABLE_HOME_MODE`               | Enable more features with home mode                                                                                | `FALSE`       |
+| `FORCE_HOSTNAME`                 | Bypass a [bug of podman](https://github.com/containers/podman/issues/8886) present in Debian Bullseye, which prevents to set the hostname | `` |
 
 
 #### Administration

--- a/install/etc/cont-init.d/10-coolwsd
+++ b/install/etc/cont-init.d/10-coolwsd
@@ -113,6 +113,10 @@ if var_true "${ENABLE_TLS}" ; then
 	fi
 fi
 
+if [ -n "$FORCE_HOSTNAME" ]; then
+	HOSTNAME="$FORCE_HOSTNAME"
+fi
+
 if [ "${SETUP_TYPE,,}" = "auto" ]; then
     print_notice "Autogenerating Configuration File"
 	### Replace Configuration directives


### PR DESCRIPTION
The version of podman in Debian Bullseye is impacted by this bug, which prevents to set the hostname
See https://github.com/containers/podman/issues/8886