### PR TITLE
🩹 — Replace APP_NAME and APP_BRAND in About dialog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ RUN source /assets/functions/00-container && \
         ${GIT_REPO_SRC_ONLINE}/configure.ac \
         ${GIT_REPO_SRC_ONLINE}/browser/admin/admin.strings.js \
         ${GIT_REPO_SRC_ONLINE}/browser/src/control/Toolbar.js \
+        ${GIT_REPO_SRC_ONLINE}/browser/src/control/Control.AboutDialog.ts \
         ${GIT_REPO_SRC_ONLINE}/browser/src/core/Socket.js \
         ${GIT_REPO_SRC_ONLINE}/browser/src/layer/marker/ProgressOverlay.js \
         ${GIT_REPO_SRC_ONLINE}/browser/src/map/Clipboard.js \


### PR DESCRIPTION
In the About modale, the app name was still `Collabora Online Development Edition` and was unbranded. This fixes that.